### PR TITLE
FOGL-2213: plugin_reconfigure should treat input argument handle properly

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -104,7 +104,7 @@ Random *random = (Random *)handle;
  */
 void plugin_reconfigure(PLUGIN_HANDLE *handle, string& newConfig)
 {
-	Random *random = (Random *)handle;
+	Random *random = (Random *)*handle;
 	Logger::getLogger()->info("Benchmark plugin new config: %s", newConfig.c_str());
 	
 	ConfigCategory configCategory(string("cfg"), newConfig);


### PR DESCRIPTION
plugin_reconfigure should treat input argument handle as PLUGIN_HANDLE*, not PLUGIN_HANDLE.